### PR TITLE
Update jamf2snipe

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -10,7 +10,7 @@
 #       https://snipeitapp.com
 #
 # LICENSE:
-#   GLPv3
+#   MIT
 #
 # CONFIGURATION:
 #   These settings are commonly found in the settings.conf file.


### PR DESCRIPTION
Fix License mentioned to reflect the actual license.

Because I would NEVER make a mistake like that while working on things. 
Resolves #81 