### PR TITLE
80 jamf token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
 # jamf2snipe
 ## Import/Sync Computers from JAMF to Snipe-IT
 ```
-usage: jamf2snipe [-h] [-v] [--dryrun] [-d] [--do_not_verify_ssl] [-r]
-                  [--no_search] [-u | -ui | -uf] [-m | -c]
+usage: jamf2snipe [-h] [-v] [--auto_incrementing] [--dryrun] [-d] [--do_not_update_jamf] [--do_not_verify_ssl] [-r] [-f] [--version] [-u | -ui | -uf] [-uns] [-m | -c]
 
-optional arguments:
--h, --help            show this help message and exit
--v, --verbose         Sets the logging level to INFO and gives you a better
-                      idea of what the script is doing.
---dryrun              This checks your config and tries to contact both the
-                      JAMFPro and Snipe-it instances, but exits before
-                      updating or syncing any assets.
--d, --debug           Sets logging to include additional DEBUG messages.
---do_not_update_jamf  Does not update Jamf with the asset tags stored in
-                      Snipe.
---do_not_verify_ssl   Skips SSL verification for all requests. Helpful when
-                      you use self-signed certificate.
--r, --ratelimited     Puts a half second delay between Snipe IT API calls to
-                      adhere to the standard 120/minute rate limit
--f, --force           Updates the Snipe asset with information from Jamf
-                      every time, despite what the timestamps indicate.
--u, --users           Checks out the item to the current user in Jamf if
-                      it's not already deployed
--ui, --users_inverse  Checks out the item to the current user in Jamf if
-                      it's already deployed
--uf, --users_force    Checks out the item to the user specified in Jamf no
-                      matter what
--uns, --users_no_search
-                      Doesn't search for any users if the specified fields
-                      in Jamf and Snipe don't match. (case insensitive)
--m, --mobiles         Runs against the Jamf mobiles endpoint only.
--c, --computers       Runs against the Jamf computers endpoint only.
+options:
+  -h, --help            show this help message and exit
+  -v, --verbose         Sets the logging level to INFO and gives you a better
+                        idea of what the script is doing.
+  --auto_incrementing   You can use this if you have auto-incrementing 
+                        enabled in your snipe instance to utilize that 
+                        instead of adding the Jamf ID for the asset tag.
+  --dryrun              This checks your config and tries to contact both 
+                        the JAMFPro and Snipe-it instances, but exits before 
+                        updating or syncing any assets.
+  -d, --debug           Sets logging to include additional DEBUG messages.
+  --do_not_update_jamf  Does not update Jamf with the asset tags stored in 
+                        Snipe.
+  --do_not_verify_ssl   Skips SSL verification for all requests. Helpful when
+                        you use self-signed certificate.
+  -r, --ratelimited     Puts a half second delay between API calls to adhere 
+                        to the standard 120/minute rate limit
+  -f, --force           Updates the Snipe asset with information from Jamf 
+                        every time, despite what the timestamps indicate.
+  --version             Prints the version and exits.
+  -u, --users           Checks out the item to the current user in Jamf if 
+                        it's not already deployed
+  -ui, --users_inverse  Checks out the item to the current user in Jamf if 
+                        it's already deployed
+  -uf, --users_force    Checks out the item to the user specified in Jamf no 
+                        matter what
+  -uns, --users_no_search
+                        Doesn't search for any users if the specified fields 
+                        in Jamf and Snipe don't match. (case insensitive)
+  -m, --mobiles         Runs against the Jamf mobiles endpoint only.
+  -c, --computers       Runs against the Jamf computers endpoint only.
 ```
 
 ## Overview:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -187,7 +187,7 @@ def request_handler(r, *args, **kwargs):
 def get_jamf_computers():
     api_url = '{0}/JSSResource/computers'.format(jamfpro_base)
     logging.debug('Calling for JAMF computers against: {}\n The username, passwords, and headers for this GET requestcan be found near the beginning of the output.'.format(api_url))
-    response = requests.get(api_url, auth=(jamf_api_user, jamf_api_password), headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.get(api_url, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 200:
         logging.debug("Got back a valid 200 response code.")
         return response.json()
@@ -207,7 +207,7 @@ def get_jamf_computers():
 def get_jamf_computers_by_group(jamf_id):
     api_url = '{0}/JSSResource/computergroups/id/{1}'.format(jamfpro_base, jamf_id)
     logging.debug('Calling for JAMF computers against: {}\n The username, passwords, and headers for this GET requestcan be found near the beginning of the output.'.format(api_url))
-    response = requests.get(api_url, auth=(jamf_api_user, jamf_api_password), headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.get(api_url, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 200:
         logging.debug("Got back a valid 200 response code.")
         jsonresponse = response.json()
@@ -229,7 +229,7 @@ def get_jamf_computers_by_group(jamf_id):
 def get_jamf_mobiles():
     api_url = '{0}/JSSResource/mobiledevices'.format(jamfpro_base)
     logging.debug('Calling for JAMF mobiles against: {}\n The username, passwords, and headers for this GET requestcan be found near the beginning of the output.'.format(api_url))
-    response = requests.get(api_url, auth=(jamf_api_user, jamf_api_password), headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.get(api_url, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 200:
         logging.debug("Got back a valid 200 response code.")
         return response.json()
@@ -249,7 +249,7 @@ def get_jamf_mobiles():
 def get_jamf_mobiles_by_group(jamf_id):
     api_url = '{0}/JSSResource/mobiledevicegroups/id/{1}'.format(jamfpro_base, jamf_id)
     logging.debug('Calling for JAMF mobiles against: {}\n The username, passwords, and headers for this GET requestcan be found near the beginning of the output.'.format(api_url))
-    response = requests.get(api_url, auth=(jamf_api_user, jamf_api_password), headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.get(api_url, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 200:
         logging.debug("Got back a valid 200 response code.")
         jsonresponse = response.json()
@@ -270,7 +270,7 @@ def get_jamf_mobiles_by_group(jamf_id):
 # Function to lookup a JAMF asset by id.
 def search_jamf_asset(jamf_id):
     api_url = "{}/JSSResource/computers/id/{}".format(jamfpro_base, jamf_id)
-    response = requests.get(api_url, auth=(jamf_api_user, jamf_api_password), headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.get(api_url, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 200:
         logging.debug("Got back a valid 200 response code.")
         jsonresponse = response.json()
@@ -291,7 +291,7 @@ def search_jamf_asset(jamf_id):
 # Function to lookup a JAMF mobile asset by id.
 def search_jamf_mobile(jamf_id):
     api_url = "{}/JSSResource/mobiledevices/id/{}".format(jamfpro_base, jamf_id)
-    response = requests.get(api_url, auth=(jamf_api_user, jamf_api_password), headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.get(api_url, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 200:
         logging.debug("Got back a valid 200 response code.")
         jsonresponse = response.json()
@@ -314,7 +314,7 @@ def update_jamf_asset_tag(jamf_id, asset_tag):
     api_url = "{}/JSSResource/computers/id/{}".format(jamfpro_base, jamf_id)
     payload = """<?xml version="1.0" encoding="UTF-8"?><computer><general><id>{}</id><asset_tag>{}</asset_tag></general></computer>""".format(jamf_id, asset_tag)
     logging.debug('Making Get request against: {}\nPayload for the PUT request is: {}\nThe username, password, and headers can be found near the beginning of the output.'.format(api_url, payload))
-    response = requests.put(api_url, auth=(jamf_api_user, jamf_api_password), data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.put(api_url, data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 201:
         logging.debug("Got a 201 response. Returning: True")
         return True
@@ -337,7 +337,7 @@ def update_jamf_mobiledevice_asset_tag(jamf_id, asset_tag):
     api_url = "{}/JSSResource/mobiledevices/id/{}".format(jamfpro_base, jamf_id)
     payload = """<?xml version="1.0" encoding="UTF-8"?><mobile_device><general><id>{}</id><asset_tag>{}</asset_tag></general></mobile_device>""".format(jamf_id, asset_tag)
     logging.debug('Making Get request against: {}\nPayload for the PUT request is: {}\nThe username, password, and headers can be found near the beginning of the output.'.format(api_url, payload))
-    response = requests.put(api_url, auth=(jamf_api_user, jamf_api_password), data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.put(api_url, data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 201:
         logging.debug("Got a 201 response. Returning: True")
         return True

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -30,6 +30,8 @@
 #       _snipeit_custom_name_1234567890 = subset jamf_key
 #
 #   A list of valid subsets are:
+version = "1.0.0"
+
 validsubset = [
         "general",
         "location",
@@ -62,8 +64,9 @@ runtimeargs.add_argument("--dryrun", help="This checks your config and tries to 
 runtimeargs.add_argument("-d", "--debug", help="Sets logging to include additional DEBUG messages.", action="store_true")
 runtimeargs.add_argument("--do_not_update_jamf", help="Does not update Jamf with the asset tags stored in Snipe.", action="store_false")
 runtimeargs.add_argument('--do_not_verify_ssl', help="Skips SSL verification for all requests. Helpful when you use self-signed certificate.", action="store_false")
-runtimeargs.add_argument("-r", "--ratelimited", help="Puts a half second delay between Snipe IT API calls to adhere to the standard 120/minute rate limit", action="store_true")
+runtimeargs.add_argument("-r", "--ratelimited", help="Puts a half second delay between API calls to adhere to the standard 120/minute rate limit", action="store_true")
 runtimeargs.add_argument("-f", "--force", help="Updates the Snipe asset with information from Jamf every time, despite what the timestamps indicate.", action="store_true")
+runtimeargs.add_argument("--version", help="Prints the version and exits.", action="sture_true")
 user_opts = runtimeargs.add_mutually_exclusive_group()
 user_opts.add_argument("-u", "--users", help="Checks out the item to the current user in Jamf if it's not already deployed", action="store_true")
 user_opts.add_argument("-ui", "--users_inverse", help="Checks out the item to the current user in Jamf if it's already deployed", action="store_true")
@@ -73,6 +76,10 @@ type_opts = runtimeargs.add_mutually_exclusive_group()
 type_opts.add_argument("-m", "--mobiles", help="Runs against the Jamf mobiles endpoint only.", action="store_true")
 type_opts.add_argument("-c", "--computers", help="Runs against the Jamf computers endpoint only.", action="store_true")
 user_args = runtimeargs.parse_args()
+
+if user_args.version:
+    print(version)
+    raise SystemExit
 
 # Notify users they're going to get a wall of text in verbose mode.
 if user_args.verbose:
@@ -117,7 +124,7 @@ try:
     logging.debug("The user you provided for Jamf is: {}".format(jamf_user))
 
     logging.info("Setting the password to request an api key.")
-    jamf_user = config['jamf']['password']
+    jamf_password = config['jamf']['password']
     logging.debug("The password you provided for Jamf is: {}".format(jamf_user))    
     
     # This is the address, cname, or FQDN for your snipe-it instance.
@@ -140,13 +147,6 @@ try:
 except:
     logging.error("Some of the required settings from the settings.conf were missing or invalid. Re-run jamf2snipe with the --verbose or --debug flag to get more details on which setting is missing or misconfigured.")
     raise SystemExit("Error: Missing or invalid settings in settings.conf - Exiting.")
-
-
-# Headers for the API call.
-logging.info("Creating the headers we'll need for API calls")
-jamfheaders = {'Authorization': 'Bearer {}'.format(jamf_apiKey),'Accept': 'application/json','Content-Type':'application/json'}
-snipeheaders = {'Authorization': 'Bearer {}'.format(snipe_apiKey),'Accept': 'application/json','Content-Type':'application/json'}
-logging.debug('Request headers for JamfPro will be: {}\nRequest headers for Snipe will be: {}'.format(jamfheaders, snipeheaders))
 
 # Check the config file for correct headers
 
@@ -175,30 +175,84 @@ for key in config['computers-api-mapping']:
         raise SystemExit("Invalid Subset found in settings.conf")
 
 ### Setup Some Functions ###
-snipe_api_count = 0
-first_snipe_call = None
-# This function is run every time a request is made, handles rate limiting for Snipe IT.
+api_count = 0
+first_api_call = None
+
+# Headers for the API call.
+logging.info("Creating the headers we'll need for API calls")
+jamfbasicheaders = {'Accept': 'application/json','Content-Type':'application/json'}
+snipeheaders = {'Authorization': 'Bearer {}'.format(snipe_apiKey),'Accept': 'application/json','Content-Type':'application/json'}
+logging.debug('Request headers for JamfPro will be: {}\nRequest headers for Snipe will be: {}'.format(jamfbasicheaders, snipeheaders))
+
+# Use Basic Auth to request a Jamf Token. 
+def request_jamf_token():
+    # Tokens expire after 60 minutes, but we can't be sure that we're in the same TZ as the Jamf server, so we'll set up a timer.
+    global token_request_time
+    global jamf_apiKey
+    global jamfheaders
+    global expires_time
+    token_request_time = time.time()
+    logging.info("Requesting a new token at {}.".format(token_request_time))
+    api_url = '{0}/api/v1/auth/token'.format(jamfpro_base)
+    # No hook for this api call.
+    logging.debug('Calling for a token against: {}\n The username and password can be found earlier in the script.'.format(api_url))
+    # No hook for this API call.
+    response = requests.post(api_url, auth=(jamf_user, jamf_password), headers=jamfbasicheaders, verify=user_args.do_not_verify_ssl)
+    if response.status_code == 200:
+        logging.debug("Got back a valid 200 response code.")
+        jsonresponse = response.json()
+        logging.debug(jsonresponse)
+        # So we have our token and Expires time. Set the expires time globably so we can reset later. 
+        try:
+            expires_time = datetime.datetime.fromisoformat(jsonresponse['expires'].replace("Z", "+00:00"))
+        except:
+            # APIs are awful and Jamf doesn't always send enough ms digits. UGH. 
+            try:
+                expires_time = datetime.datetime.fromisoformat(jsonresponse['expires'].replace("Z", "0+00:00"))
+            except:
+                logging.error("Jamf sent a malformed timestamp: {}\n Please feel free to complain to Jamf support.".format(jsonresponse['expires']))
+                raise SystemExit("Unable to grok Jamf Timestamp - Exiting")
+        logging.debug("Token expires in: {}".format(expires_time - datetime.datetime.now(datetime.timezone.utc)))
+        # The headers are also global, because they get used elsewhere. 
+        logging.info("Setting new jamf headers with bearer token") 
+        jamfheaders = {'Authorization': 'Bearer {}'.format(jsonresponse['token']),'Accept': 'application/json','Content-Type':'application/json'}
+        logging.debug('Request headers for JamfPro will be: {}\nRequest headers for Snipe will be: {}'.format(jamfheaders, snipeheaders))
+    else:
+        logging.error("Could not obtain a token for use with Jamf's classic API. Please check your username and password.")
+        raise SystemExit("Unable to obtain Jamf Token")
+
+
+# This function is run every time a request is made, handles rate limiting for Snipe IT and keeps the token fresh for Jamf. 
 def request_handler(r, *args, **kwargs):
-    global snipe_api_count
-    global first_snipe_call
-    if (snipe_base in r.url) and user_args.ratelimited:
+    global api_count
+    global first_api_call
+    global token_request_time
+
+    # We need to check to see if we need to get a new token. 
+    timeleft = expires_time - datetime.datetime.now(datetime.timezone.utc)
+    # If there's less than 5 minutes (300 seconds) left on the token, get a new one.
+    if timeleft < datetime.timedelta(seconds=300):
+        request_jamf_token()
+    
+    # Slow and steady wins the race. Limit all API calls (not just to snipe) to the Rate limit. 
+    if user_args.ratelimited:
         if '"messages":429' in r.text:
             logging.warn("Despite respecting the rate limit of Snipe, we've still been limited. Trying again after sleeping for 2 seconds.")
             time.sleep(2)
             re_req = r.request
             s = requests.Session()
             return s.send(re_req)
-        if snipe_api_count == 0:
-            first_snipe_call = time.time()
+        if api_count == 0:
+            first_api_call = time.time()
             time.sleep(0.5)
-        snipe_api_count += 1
-        time_elapsed = (time.time() - first_snipe_call)
-        snipe_api_rate = snipe_api_count / time_elapsed
-        if snipe_api_rate > 1.95:
-            sleep_time = 0.5 + (snipe_api_rate - 1.95)
-            logging.debug('Going over snipe rate limit of 120/minute ({}/minute), sleeping for {}'.format(snipe_api_rate,sleep_time))
+        api_count += 1
+        time_elapsed = (time.time() - first_api_call)
+        api_rate = api_count / time_elapsed
+        if api_rate > 1.95:
+            sleep_time = 0.5 + (api_rate - 1.95)
+            logging.debug('Going over snipe rate limit of 120/minute ({}/minute), sleeping for {}'.format(api_rate,sleep_time))
             time.sleep(sleep_time)
-        logging.debug("Made {} requests to Snipe IT in {} seconds, with a request being sent every {} seconds".format(snipe_api_count, time_elapsed, snipe_api_rate))
+        logging.debug("Made {} requests to Snipe IT in {} seconds, with a request being sent every {} seconds".format(api_count, time_elapsed, api_rate))
     if '"messages":429' in r.text:
         logging.error(r.content)
         raise SystemExit("We've been rate limited. Use option -r to respect the built in Snipe IT API rate limit of 120/minute.")
@@ -610,8 +664,9 @@ else:
 if ( JAMF_UP == False ) or ( SNIPE_UP == False ):
     raise SystemExit("Error: Host could not be contacted.")
 
-# Test that we can actually connect with the API keys.
-##TODO Write some more tests here. ha!
+# Test that we can actually connect with the API keys by getting a bearer token. 
+request_jamf_token()
+
 
 logging.info("Finished running our tests.")
 

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -123,7 +123,7 @@ logging.info("The configured JAMFPro base url is: {} (Pretty sure this needs to 
 # Headers for the API call.
 
 logging.info("Creating the headers we'll need for API calls")
-jamfheaders = {'Accept': 'application/json'}
+jamfheaders = {'Authorization': 'Bearer {}'.format(jamf_apiKey),'Accept': 'application/json','Content-Type':'application/json'}
 snipeheaders = {'Authorization': 'Bearer {}'.format(snipe_apiKey),'Accept': 'application/json','Content-Type':'application/json'}
 logging.debug('Request headers for JamfPro will be: {}\nRequest headers for Snipe will be: {}'.format(jamfheaders, snipeheaders))
 

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -107,13 +107,13 @@ logging.info("Great, we found a settings file. Let's get started by parsing all 
 # This is the address, cname, or FQDN for your JamfPro instance.
 jamfpro_base = config['jamf']['url']
 logging.info("The configured JAMFPro base url is: {}".format(jamfpro_base))
-jamf_apiKey = config['jamf']['apiKey']
-logging.debug("The API key you provided to access the Jamf is: {}".format(jamf_apiKey))
+jamf_apiKey = config['jamf']['apikey']
+logging.debug("The API key you provided for Jamf is: {}".format(jamf_apiKey))
 
 # This is the address, cname, or FQDN for your snipe-it instance.
 snipe_base = config['snipe-it']['url']
 logging.info("The configured Snipe-IT base url is: {}".format(snipe_base))
-snipe_apiKey = config['snipe-it']['apiKey']
+snipe_apiKey = config['snipe-it']['apikey']
 logging.debug("The API key you provided for Snipe is: {}".format(snipe_apiKey))
 defaultStatus = config['snipe-it']['defaultStatus']
 logging.info("The default status we'll be setting updated computer to is: {} (I sure hope this is a number or something is probably wrong)".format(defaultStatus))

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -115,8 +115,8 @@ logging.debug("The configured password to access the API is: {}".format(jamf_api
 # This is the address, cname, or FQDN for your snipe-it instance.
 snipe_base = config['snipe-it']['url']
 logging.info("The configured Snipe-IT base url is: {}".format(snipe_base))
-apiKey = config['snipe-it']['apiKey']
-logging.debug("The API key you provided for Snipe is: {}".format(apiKey))
+snipe_apiKey = config['snipe-it']['apiKey']
+logging.debug("The API key you provided for Snipe is: {}".format(snipe_apiKey))
 defaultStatus = config['snipe-it']['defaultStatus']
 logging.info("The default status we'll be setting updated computer to is: {} (I sure hope this is a number or something is probably wrong)".format(defaultStatus))
 apple_manufacturer_id = config['snipe-it']['manufacturer_id']
@@ -126,7 +126,7 @@ logging.info("The configured JAMFPro base url is: {} (Pretty sure this needs to 
 
 logging.info("Creating the headers we'll need for API calls")
 jamfheaders = {'Accept': 'application/json'}
-snipeheaders = {'Authorization': 'Bearer {}'.format(apiKey),'Accept': 'application/json','Content-Type':'application/json'}
+snipeheaders = {'Authorization': 'Bearer {}'.format(snipe_apiKey),'Accept': 'application/json','Content-Type':'application/json'}
 logging.debug('Request headers for JamfPro will be: {}\nRequest headers for Snipe will be: {}'.format(jamfheaders, snipeheaders))
 
 # Check the config file for correct headers
@@ -492,7 +492,7 @@ def update_snipe_asset(snipe_id, payload):
     if response.status_code == 200:
         logging.debug("Got back status code: 200 - Checking the payload updated properly: If you error here it's because you configure the API mapping right.")
         jsonresponse = response.json()
-        # Check if there's an Error and Log it, or parse the payload. 
+        # Check if there's an Error and Log it, or parse the payload.
         if jsonresponse['status'] == "error":
             logging.error('Unable to update ID: {}. Error "{}"'.format(snipe_id, jsonresponse['messages']))
             goodupdate = False
@@ -749,7 +749,7 @@ for jamf_type in jamf_types:
                         newasset[snipekey] = jamf_value
                     except KeyError:
                         continue
-                # Reset the payload without the asset_tag if auto_incrementing flag is set. 
+                # Reset the payload without the asset_tag if auto_incrementing flag is set.
                 if user_args.auto_incrementing:
                     newasset.pop('asset_tag', None)
                 new_snipe_asset = create_snipe_asset(newasset)
@@ -828,7 +828,7 @@ for jamf_type in jamf_types:
 
                 if updates:
                     update_snipe_asset(snipe_id, updates)
-                
+
                 if ((user_args.users or user_args.users_inverse) and (snipe['rows'][0]['assigned_to'] == None) == user_args.users) or user_args.users_force:
 
                     if snipe['rows'][0]['status_label']['status_meta'] in ('deployable', 'deployed'):
@@ -845,7 +845,7 @@ for jamf_type in jamf_types:
                 logging.debug("Not updating the Snipe asset because Snipe has a more recent timestamp: {} < {}".format(jamf_time, snipe_time))
 
             # Update/Sync the Snipe Asset Tag Number back to JAMF
-            # The user arg below is set to false if it's called, so this would fail if the user called it. 
+            # The user arg below is set to false if it's called, so this would fail if the user called it.
             if (jamf['general']['asset_tag'] != snipe['rows'][0]['asset_tag']) and user_args.do_not_update_jamf :
                 logging.info("JAMF doesn't have the same asset tag as SNIPE so we'll update it because it should be authoritative.")
                 if snipe['rows'][0]['asset_tag'][0]:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -66,7 +66,7 @@ runtimeargs.add_argument("--do_not_update_jamf", help="Does not update Jamf with
 runtimeargs.add_argument('--do_not_verify_ssl', help="Skips SSL verification for all requests. Helpful when you use self-signed certificate.", action="store_false")
 runtimeargs.add_argument("-r", "--ratelimited", help="Puts a half second delay between API calls to adhere to the standard 120/minute rate limit", action="store_true")
 runtimeargs.add_argument("-f", "--force", help="Updates the Snipe asset with information from Jamf every time, despite what the timestamps indicate.", action="store_true")
-runtimeargs.add_argument("--version", help="Prints the version and exits.", action="sture_true")
+runtimeargs.add_argument("--version", help="Prints the version and exits.", action="store_true")
 user_opts = runtimeargs.add_mutually_exclusive_group()
 user_opts.add_argument("-u", "--users", help="Checks out the item to the current user in Jamf if it's not already deployed", action="store_true")
 user_opts.add_argument("-ui", "--users_inverse", help="Checks out the item to the current user in Jamf if it's already deployed", action="store_true")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -104,25 +104,45 @@ if 'snipe-it' not in set(config):
 
 logging.info("Great, we found a settings file. Let's get started by parsing all fo the settings.")
 
-# Set some Variables from the settings.conf:
-# This is the address, cname, or FQDN for your JamfPro instance.
-jamfpro_base = config['jamf']['url']
-logging.info("The configured JAMFPro base url is: {}".format(jamfpro_base))
-jamf_apiKey = config['jamf']['apikey']
-logging.debug("The API key you provided for Jamf is: {}".format(jamf_apiKey))
+# While setting the variables, use a try loop so we can raise a error if something goes wrong. 
+try:
+    # Set some Variables from the settings.conf:
+    # This is the address, cname, or FQDN for your JamfPro instance.
+    logging.info("Setting the Jamf Pro Base url.")
+    jamfpro_base = config['jamf']['url']
+    logging.debug("The configured Jamf Pro base url is: {}".format(jamfpro_base))
 
-# This is the address, cname, or FQDN for your snipe-it instance.
-snipe_base = config['snipe-it']['url']
-logging.info("The configured Snipe-IT base url is: {}".format(snipe_base))
-snipe_apiKey = config['snipe-it']['apikey']
-logging.debug("The API key you provided for Snipe is: {}".format(snipe_apiKey))
-defaultStatus = config['snipe-it']['defaultStatus']
-logging.info("The default status we'll be setting updated computer to is: {} (I sure hope this is a number or something is probably wrong)".format(defaultStatus))
-apple_manufacturer_id = config['snipe-it']['manufacturer_id']
-logging.info("The configured JAMFPro base url is: {} (Pretty sure this needs to be a number too)".format(apple_manufacturer_id))
+    logging.info("Setting the username to request an api key.")
+    jamf_user = config['jamf']['user']
+    logging.debug("The user you provided for Jamf is: {}".format(jamf_user))
+
+    logging.info("Setting the password to request an api key.")
+    jamf_user = config['jamf']['password']
+    logging.debug("The password you provided for Jamf is: {}".format(jamf_user))    
+    
+    # This is the address, cname, or FQDN for your snipe-it instance.
+    logging.info("Setting the base URL for SnipeIT.")
+    snipe_base = config['snipe-it']['url']
+    logging.debug("The configured Snipe-IT base url is: {}".format(snipe_base))
+    
+    logging.info("Setting the API key for SnipeIT.") 
+    snipe_apiKey = config['snipe-it']['apikey']
+    logging.debug("The API key you provided for Snipe is: {}".format(snipe_apiKey))
+    
+    logging.info("Setting the default status for SnipeIT assets.")
+    defaultStatus = config['snipe-it']['defaultStatus']
+    logging.debug("The default status we'll be setting updated assets to is: {} (I sure hope this is a number or something is probably wrong)".format(defaultStatus))
+    
+    logging.info("Setting the Snipe ID for Apple Manufacturer devices.")
+    apple_manufacturer_id = config['snipe-it']['manufacturer_id']
+    logging.debug("The configured manufacturer ID for Apple computers in snipe is: {} (Pretty sure this needs to be a number too)".format(apple_manufacturer_id))
+
+except:
+    logging.error("Some of the required settings from the settings.conf were missing or invalid. Re-run jamf2snipe with the --verbose or --debug flag to get more details on which setting is missing or misconfigured.")
+    raise SystemExit("Error: Missing or invalid settings in settings.conf - Exiting.")
+
 
 # Headers for the API call.
-
 logging.info("Creating the headers we'll need for API calls")
 jamfheaders = {'Authorization': 'Bearer {}'.format(jamf_apiKey),'Accept': 'application/json','Content-Type':'application/json'}
 snipeheaders = {'Authorization': 'Bearer {}'.format(snipe_apiKey),'Accept': 'application/json','Content-Type':'application/json'}

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -52,6 +52,7 @@ import time
 import configparser
 import argparse
 import logging
+import datetime
 
 # Set us up for using runtime arguments by defining them.
 runtimeargs = argparse.ArgumentParser()

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -107,10 +107,8 @@ logging.info("Great, we found a settings file. Let's get started by parsing all 
 # This is the address, cname, or FQDN for your JamfPro instance.
 jamfpro_base = config['jamf']['url']
 logging.info("The configured JAMFPro base url is: {}".format(jamfpro_base))
-jamf_api_user = config['jamf']['username']
-logging.info("The configured JAMFPro username we'll be connecting with is: {}".format(jamf_api_user))
-jamf_api_password = config['jamf']['password']
-logging.debug("The configured password to access the API is: {}".format(jamf_api_password))
+jamf_apiKey = config['jamf']['apiKey']
+logging.debug("The API key you provided to access the Jamf is: {}".format(jamf_apiKey))
 
 # This is the address, cname, or FQDN for your snipe-it instance.
 snipe_base = config['snipe-it']['url']

--- a/settings.conf.example
+++ b/settings.conf.example
@@ -1,6 +1,8 @@
 [jamf]
+# This entire section is Required
 url = https://yourinstance.jamfcloud.com
-apikey = YOUR-API-KEY-HERE
+user = yourJamfUsername
+password = $ecretJ@mfPassw0rd
 
 [snipe-it]
 #Required

--- a/settings.conf.example
+++ b/settings.conf.example
@@ -1,7 +1,6 @@
 [jamf]
 url = https://yourinstance.jamfcloud.com
-username = a-valid-username
-password = a-valid-password
+apikey = YOUR-API-KEY-HERE
 
 [snipe-it]
 #Required


### PR DESCRIPTION
- Adds better logging for the settings. (which I had to change and noticed was straight up wrong in places. Oops.) 
- Adds a new --version flag so we can help each other by not reporting old bugs.
- Gets tokens automatically with basic auth. I'm not sure how this is absolutely better than just using basic auth for all the calls, but ok. Replaces the token/headers within 5 minutes of the token expiring. 
- Gets a token against the Jamf API as part of the dryrun, which has the added bonus of being another test. 