### PR TITLE
Release 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Lastly, if the asset_tag field is blank in JAMF when it is being created in Snip
 
 - Python3 is installed on your system with the requests, json, time, and configparser python libs installed.
 - Network access to both your JAMF and Snipe-IT environments.
-- A JAMF username and password that has read & write permissions for computer assets.
+- A JAMF username and password that has read & write permissions for computer assets, mobile device assets, and users.
   - Computers: Read, Update
+  - Mobile Devices: Read, Update
+  - Users: Read, Update
 - Snipe API key for a user that has edit/create permissions for assets and models. Snipe-IT documentation instructions for creating API keys: [https://snipe-it.readme.io/reference#generating-api-tokens](https://snipe-it.readme.io/reference#generating-api-tokens)
 
 ## Installation:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -205,6 +205,28 @@ def get_jamf_computers():
         logging.debug("Returning a null value for the function.")
         return None
 
+# Function to make the API call for JAMF devices in group
+def get_jamf_computers_by_group(jamf_id):
+    api_url = '{0}/JSSResource/computergroups/id/{1}'.format(jamfpro_base, jamf_id)
+    logging.debug('Calling for JAMF computers against: {}\n The username, passwords, and headers for this GET requestcan be found near the beginning of the output.'.format(api_url))
+    response = requests.get(api_url, auth=(jamf_api_user, jamf_api_password), headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    if response.status_code == 200:
+        logging.debug("Got back a valid 200 response code.")
+        jsonresponse = response.json()
+        logging.debug("Returning: {}".format(jsonresponse['computer_group']))
+        return jsonresponse['computer_group']
+    elif b'policies.ratelimit.QuotaViolation' in response.content:
+        logging.info('JAMFPro responded with error code: {} - Policy Ratelimit Quota Violation - when we tried to get a list of computers Waiting a bit to retry the lookup.'.format(response))
+        logging.warning('JAMFPro Ratelimit exceeded: pausing ')
+        time.sleep(75)
+        logging.info("Finished waiting. Retrying lookup...")
+        newresponse = get_jamf_computers_by_group(jamf_id)
+        return newresponse
+    else:
+        logging.warning('Received an invalid status code when trying to retreive JAMF Device list:{} - {}'.format(response.status_code, response.content))
+        logging.debug("Returning a null value for the function.")
+        return None
+
 # Function to make the API call for all JAMF mobile devices
 def get_jamf_mobiles():
     api_url = '{0}/JSSResource/mobiledevices'.format(jamfpro_base)
@@ -218,7 +240,29 @@ def get_jamf_mobiles():
         logging.warning('JAMFPro Ratelimit exceeded: pausing ')
         time.sleep(75)
         logging.info("Finished waiting. Retrying lookup...")
-        newresponse = get_jamf_computers()
+        newresponse = get_jamf_mobiles()
+        return newresponse
+    else:
+        logging.warning('Received an invalid status code when trying to retreive JAMF Device list:{} - {}'.format(response.status_code, response.content))
+        logging.debug("Returning a null value for the function.")
+        return None
+
+# Function to make the API call for all JAMF mobile devices in group
+def get_jamf_mobiles_by_group(jamf_id):
+    api_url = '{0}/JSSResource/mobiledevicegroups/id/{1}'.format(jamfpro_base, jamf_id)
+    logging.debug('Calling for JAMF mobiles against: {}\n The username, passwords, and headers for this GET requestcan be found near the beginning of the output.'.format(api_url))
+    response = requests.get(api_url, auth=(jamf_api_user, jamf_api_password), headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    if response.status_code == 200:
+        logging.debug("Got back a valid 200 response code.")
+        jsonresponse = response.json()
+        logging.debug("Returning: {}".format(jsonresponse['mobile_device_group']))
+        return jsonresponse['mobile_device_group']
+    elif b'policies.ratelimit.QuotaViolation' in response.content:
+        logging.info('JAMFPro responded with error code: {} - Policy Ratelimit Quota Violation - when we tried to get a list of mobiles Waiting a bit to retry the lookup.'.format(response))
+        logging.warning('JAMFPro Ratelimit exceeded: pausing ')
+        time.sleep(75)
+        logging.info("Finished waiting. Retrying lookup...")
+        newresponse = get_jamf_mobiles_by_group(jamf_id)
         return newresponse
     else:
         logging.warning('Received an invalid status code when trying to retreive JAMF Device list:{} - {}'.format(response.status_code, response.content))
@@ -372,7 +416,7 @@ def get_snipe_users(previous=[]):
     response = requests.get(user_id_url, headers=snipeheaders, json=payload, hooks={'response': request_handler})
     response_json = response.json()
     current = response_json['rows']
-    if len(previous) is not 0:
+    if len(previous) != 0:
         current = previous + current
     if response_json['total'] > len(current):
         logging.debug('We have more than 100 users, get the next page - total: {} current: {}'.format(response_json['total'], len(current)))
@@ -429,10 +473,14 @@ def create_snipe_asset(payload):
     logging.debug(response.text)
     if response.status_code == 200:
         logging.debug("Got back status code: 200 - {}".format(response.content))
+        jsonresponse = response.json()
+        if jsonresponse['status'] == "error":
+            logging.error('Asset creation failed for asset {} with error {}'.format(payload['name'],jsonresponse['messages']))
+            return 'ERROR', response
         return 'AssetCreated', response
     else:
         logging.error('Asset creation failed for asset {} with error {}'.format(payload['name'],response.text))
-        return response
+        return 'ERROR', response
 
 # Function that updates a snipe asset with a JSON payload
 def update_snipe_asset(snipe_id, payload):
@@ -444,15 +492,23 @@ def update_snipe_asset(snipe_id, payload):
     if response.status_code == 200:
         logging.debug("Got back status code: 200 - Checking the payload updated properly: If you error here it's because you configure the API mapping right.")
         jsonresponse = response.json()
-        for key in payload:
-            if jsonresponse['payload'][key] != payload[key]:
-                logging.warning('Unable to update ID: {}. We failed to update the {} field with "{}"'.format(snipe_id, key, payload[key]))
-                goodupdate = False
-            else:
-                logging.info("Sucessfully updated {} with: {}".format(key, payload[key]))
+        if jsonresponse['status'] == "error":
+            logging.error('Unable to update ID: {}. Error "{}"'.format(snipe_id, jsonresponse['messages']))
+            goodupdate = False
+        else:
+            for key in payload:
+                if key == 'purchase_date':
+                    payload[key] = payload[key] + " 00:00:00"
+                if payload[key] == '':
+                    payload[key] = None
+                if jsonresponse['payload'][key] != payload[key]:
+                    logging.warning('Unable to update ID: {}. We failed to update the {} field with "{}"'.format(snipe_id, key, payload[key]))
+                    goodupdate = False
+                else:
+                    logging.info("Sucessfully updated {} with: {}".format(key, payload[key]))
         return goodupdate
     else:
-        logging.warning('Whoops. Got an error status code while updating ID {}: {} - {}'.format(snipe_id, response.status_code, response.content))
+        logging.error('Whoops. Got an error status code while updating ID {}: {} - {}'.format(snipe_id, response.status_code, response.content))
         return False
 
 # Function that checks in an asset in snipe
@@ -511,19 +567,21 @@ logging.info("SSL Verification is set to: {}".format(user_args.do_not_verify_ssl
 # Do some tests to see if the hosts are up.
 logging.info("Running tests to see if hosts are up.")
 try:
-    SNIPE_UP = True if requests.get(snipe_base, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler}).status_code is 200 else False
-except:
+    SNIPE_UP = True if requests.get(snipe_base, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler}).status_code == 200 else False
+except Exception as e:
+    logging.exception(e)
     SNIPE_UP = False
 try:
     JAMF_UP = True if requests.get(jamfpro_base, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler}).status_code in (200, 401) else False
-except:
+except Exception as e:
+    logging.exception(e)
     JAMF_UP = False
 
-if SNIPE_UP is False:
+if not SNIPE_UP:
     logging.error('Snipe-IT looks like it is down from here. \nPlease check your config in the settings.conf file, or your instance.')
 else:
     logging.info('We were able to get a good response from your Snipe-IT instance.')
-if JAMF_UP is False:
+if not JAMF_UP:
     logging.error('JAMFPro looks down from here. \nPlease check the your config in the settings.conf file, or your hosted JAMFPro instance.')
 else:
     logging.info('We were able to get a good response from your JAMFPro instance.')
@@ -544,7 +602,7 @@ snipemodels = get_snipe_models()
 logging.debug("Parsing the {} model results for models with model numbers.".format(len(snipemodels['rows'])))
 modelnumbers = {}
 for model in snipemodels['rows']:
-    if model['model_number'] is "":
+    if model['model_number'] == "":
         logging.debug("The model, {}, did not have a model number. Skipping.".format(model['name']))
         continue
     modelnumbers[model['model_number']] =  model['id']
@@ -552,8 +610,17 @@ logging.info("Our list of models has {} entries.".format(len(modelnumbers)))
 logging.debug("Here's the list of the {} models and their id's that we were able to collect:\n{}".format(len(modelnumbers), modelnumbers))
 
 # Get the IDS of all active assets.
-jamf_computer_list = get_jamf_computers()
-jamf_mobile_list = get_jamf_mobiles()
+if 'computer_group_id' in config['jamf'] and config['jamf']['computer_group_id']:
+    logging.info("Getting list of computers from JAMF by computer group id.")
+    jamf_computer_list = get_jamf_computers_by_group(config['jamf']['computer_group_id'])
+else:
+    jamf_computer_list = get_jamf_computers()
+
+if 'mobile_group_id' in config['jamf'] and config['jamf']['mobile_group_id']:
+    logging.info("Getting list of mobiles from JAMF by mobile group id.")
+    jamf_mobile_list = get_jamf_mobiles_by_group(config['jamf']['mobile_group_id'])
+else:
+    jamf_mobile_list = get_jamf_mobiles()
 jamf_types = {
     'computers': jamf_computer_list,
     'mobile_devices': jamf_mobile_list
@@ -575,7 +642,7 @@ else:
         TotalNumber += len(jamf_types[jamf_type][jamf_type])
 
 # Make sure we have a good list.
-if jamf_computer_list is not None:
+if jamf_computer_list != None:
     logging.info('Received a list of JAMF assets that had {} entries.'.format(TotalNumber))
 else:
     logging.error("We were not able to retreive a list of assets from your JAMF instance. It's likely that your settings, or credentials are incorrect. Check your settings.conf and verify you can make API calls outside of this system with the credentials found in your settings.conf")
@@ -604,7 +671,7 @@ for jamf_type in jamf_types:
             jamf = search_jamf_asset(jamf_asset['id'])
         elif jamf_type == 'mobile_devices':
             jamf = search_jamf_mobile(jamf_asset['id'])
-        if jamf is None:
+        if jamf == None:
             continue
 
         # Check that the model number exists in snipe, if not create it.
@@ -629,10 +696,10 @@ for jamf_type in jamf_types:
         snipe = search_snipe_asset(jamf['general']['serial_number'])
 
         # Create a new asset if there's no match:
-        if snipe is 'NoMatch':
+        if snipe == 'NoMatch':
             logging.info("Creating a new asset in snipe for JAMF ID {} - {}".format(jamf['general']['id'], jamf['general']['name']))
             # This section checks to see if the asset tag was already put into JAMF, if not it creates one with with Jamf's ID.
-            if jamf['general']['asset_tag'] is '':
+            if jamf['general']['asset_tag'] == '':
                 jamf_asset_tag = None
                 logging.debug('No asset tag found in Jamf, checking settings.conf for alternative specified field.')
                 if 'asset_tag' in config['snipe-it']:
@@ -641,7 +708,7 @@ for jamf_type in jamf_types:
                         jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
                     except:
                         raise SystemError('No such attribute {} in the jamf payload. Please check your settings.conf file'.format(tag_split))
-                if jamf_asset_tag is None or jamf_asset_tag is '':
+                if jamf_asset_tag == None or jamf_asset_tag == '':
                     logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')
                     if jamf_type == 'mobile_devices':
                         jamf_asset_tag = 'jamfid-m-{}'.format(jamf['general']['id'])
@@ -661,6 +728,26 @@ for jamf_type in jamf_types:
                 logging.warning("The serial number is not available in JAMF. This is normal for DEP enrolled devices that have not yet checked in for the first time. Since there's no serial number yet, we'll skip it for now.")
                 continue
             else:
+                for snipekey in config['{}-api-mapping'.format(jamf_type)]:
+                    jamfsplit = config['{}-api-mapping'.format(jamf_type)][snipekey].split()
+                    try:
+                        for i, item in enumerate(jamfsplit):
+                            try:
+                                item = int(item)
+                            except ValueError:
+                                logging.debug('{} is not an integer'.format(item))
+                            if i == 0:
+                                jamf_value = jamf[item]
+                            else:
+                                if jamfsplit[0] == 'extension_attributes':
+                                    for attribute in jamf_value:
+                                        if attribute['id'] == item:
+                                            jamf_value = attribute['value']
+                                else:
+                                    jamf_value = jamf_value[item]
+                        newasset[snipekey] = jamf_value
+                    except KeyError:
+                        continue
                 # Reset the payload without the asset_tag if auto_incrementing flag is set. 
                 if user_args.auto_incrementing:
                     newasset.pop('asset_tag', None)
@@ -676,9 +763,9 @@ for jamf_type in jamf_types:
                     checkout_snipe_asset(jamf['{}'.format(jamfsplit[0])]['{}'.format(jamfsplit[1])],new_snipe_asset[1].json()['payload']['id'], "NewAsset")
 
         # Log an error if there's an issue, or more than once match.
-        elif snipe is 'MultiMatch':
+        elif snipe == 'MultiMatch':
             logging.warning("WARN: You need to resolve multiple assets with the same serial number in your inventory. If you can't find them in your inventory, you might need to purge your deleted records. You can find that in the Snipe Admin settings. Skipping serial number {} for now.".format(jamf['general']['serial_number']))
-        elif snipe is 'ERROR':
+        elif snipe == 'ERROR':
             logging.error("We got an error when looking up serial number {} in snipe, which shouldn't happen at this point. Check your snipe instance and setup. Skipping for now.".format(jamf['general']['serial_number']))
 
         else:
@@ -694,30 +781,35 @@ for jamf_type in jamf_types:
                 if user_args.force:
                     logging.debug("Forced the Update regardless of the timestamps below.")
                 logging.debug("Updating the Snipe asset because JAMF has a more recent timestamp: {} > {} or the Snipe Record is new".format(jamf_time, snipe_time))
+                updates = {}
                 for snipekey in config['{}-api-mapping'.format(jamf_type)]:
-                    jamfsplit = config['{}-api-mapping'.format(jamf_type)][snipekey].split()
-                    for i, item in enumerate(jamfsplit):
-                        try:
-                            item = int(item)
-                        except ValueError:
-                            logging.debug('{} is not an integer'.format(item))
-                        if i == 0:
-                            jamf_value = jamf[item]
-                        else:
-                            if jamfsplit[0] == 'extension_attributes':
-                                for attribute in jamf_value:
-                                    if attribute['id'] == item:
-                                        jamf_value = attribute['value']
+                    try:
+                        jamfsplit = config['{}-api-mapping'.format(jamf_type)][snipekey].split()
+                        for i, item in enumerate(jamfsplit):
+                            try:
+                                item = int(item)
+                            except ValueError:
+                                logging.debug('{} is not an integer'.format(item))
+                            if i == 0:
+                                jamf_value = jamf[item]
                             else:
-                                jamf_value = jamf_value[item]
-                    payload = {snipekey: jamf_value}
-                    latestvalue = jamf_value
+                                if jamfsplit[0] == 'extension_attributes':
+                                    for attribute in jamf_value:
+                                        if attribute['id'] == item:
+                                            jamf_value = attribute['value']
+                                else:
+                                    jamf_value = jamf_value[item]
+                        payload = {snipekey: jamf_value}
+                        latestvalue = jamf_value
+                    except KeyError:
+                        logging.debug("Skipping the payload, because the JAMF key we're mapping to doesn't exist")
+                        continue
 
                     # Need to check that we're not needlessly updating the asset.
                     # If it's a custom value it'll fail the first section and send it to except section that will parse custom sections.
                     try:
                         if snipe['rows'][0][snipekey] != latestvalue:
-                            update_snipe_asset(snipe_id, payload)
+                            updates.update(payload)
                         else:
                             logging.debug("Skipping the payload, because it already exits.")
                     except:
@@ -725,13 +817,17 @@ for jamf_type in jamf_types:
                         needsupdate = False
                         for CustomField in snipe['rows'][0]['custom_fields']:
                             if snipe['rows'][0]['custom_fields'][CustomField]['field'] == snipekey :
-                                if snipe['rows'][0]['custom_fields'][CustomField]['value'] != latestvalue:
+                                if snipe['rows'][0]['custom_fields'][CustomField]['value'] != str(latestvalue):
                                     logging.debug("Found the field, and the value needs to be updated from {} to {}".format(snipe['rows'][0]['custom_fields'][CustomField]['value'], latestvalue))
                                     needsupdate = True
-                        if needsupdate is True:
-                            update_snipe_asset(snipe_id, payload)
+                        if needsupdate == True:
+                            updates.update(payload)
                         else:
                             logging.debug("Skipping the payload, because it already exists, or the Snipe key we're mapping to doesn't.")
+
+                if updates:
+                    update_snipe_asset(snipe_id, updates)
+                
                 if ((user_args.users or user_args.users_inverse) and (snipe['rows'][0]['assigned_to'] == None) == user_args.users) or user_args.users_force:
 
                     if snipe['rows'][0]['status_label']['status_meta'] in ('deployable', 'deployed'):
@@ -751,7 +847,7 @@ for jamf_type in jamf_types:
             # The user arg below is set to false if it's called, so this would fail if the user called it. 
             if (jamf['general']['asset_tag'] != snipe['rows'][0]['asset_tag']) and user_args.do_not_update_jamf :
                 logging.info("JAMF doesn't have the same asset tag as SNIPE so we'll update it because it should be authoritative.")
-                if snipe['rows'][0]['asset_tag'][0].isdigit():
+                if snipe['rows'][0]['asset_tag'][0]:
                     if jamf_type == 'computers':
                        update_jamf_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
                        logging.info("Device is a computer, updating computer record")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -56,6 +56,7 @@ import logging
 # Set us up for using runtime arguments by defining them.
 runtimeargs = argparse.ArgumentParser()
 runtimeargs.add_argument("-v", "--verbose", help="Sets the logging level to INFO and gives you a better idea of what the script is doing.", action="store_true")
+runtimeargs.add_argument("--auto_incrementing", help="You can use this if you have auto-incrementing enabled in your snipe instance to utilize that instead of adding the Jamf ID for the asset tag.", action="store_true")
 runtimeargs.add_argument("--dryrun", help="This checks your config and tries to contact both the JAMFPro and Snipe-it instances, but exits before updating or syncing any assets.", action="store_true")
 runtimeargs.add_argument("-d", "--debug", help="Sets logging to include additional DEBUG messages.", action="store_true")
 runtimeargs.add_argument("--do_not_update_jamf", help="Does not update Jamf with the asset tags stored in Snipe.", action="store_false")
@@ -660,6 +661,9 @@ for jamf_type in jamf_types:
                 logging.warning("The serial number is not available in JAMF. This is normal for DEP enrolled devices that have not yet checked in for the first time. Since there's no serial number yet, we'll skip it for now.")
                 continue
             else:
+                # Reset the payload without the asset_tag if auto_incrementing flag is set. 
+                if user_args.auto_incrementing:
+                    newasset.pop('asset_tag', None)
                 new_snipe_asset = create_snipe_asset(newasset)
                 if new_snipe_asset[0] != "AssetCreated":
                     continue

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -10,7 +10,7 @@
 #       https://snipeitapp.com
 #
 # LICENSE:
-#   GLPv3
+#   MIT
 #
 # CONFIGURATION:
 #   These settings are commonly found in the settings.conf file.

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -30,7 +30,7 @@
 #       _snipeit_custom_name_1234567890 = subset jamf_key
 #
 #   A list of valid subsets are:
-version = "1.0.0"
+version = "1.0.1"
 
 validsubset = [
         "general",
@@ -120,7 +120,7 @@ try:
     logging.debug("The configured Jamf Pro base url is: {}".format(jamfpro_base))
 
     logging.info("Setting the username to request an api key.")
-    jamf_user = config['jamf']['user']
+    jamf_user = config['jamf']['username']
     logging.debug("The user you provided for Jamf is: {}".format(jamf_user))
 
     logging.info("Setting the password to request an api key.")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -638,15 +638,15 @@ def checkout_snipe_asset(user, asset_id, checked_out_user=None):
 # Report if we're verifying SSL or not.
 logging.info("SSL Verification is set to: {}".format(user_args.do_not_verify_ssl))
 
-# Do some tests to see if the hosts are up.
+# Do some tests to see if the hosts are up. Don't use hooks for these as we don't have tokens yet. 
 logging.info("Running tests to see if hosts are up.")
 try:
-    SNIPE_UP = True if requests.get(snipe_base, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler}).status_code == 200 else False
+    SNIPE_UP = True if requests.get(snipe_base, verify=user_args.do_not_verify_ssl).status_code == 200 else False
 except Exception as e:
     logging.exception(e)
     SNIPE_UP = False
 try:
-    JAMF_UP = True if requests.get(jamfpro_base, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler}).status_code in (200, 401) else False
+    JAMF_UP = True if requests.get(jamfpro_base, verify=user_args.do_not_verify_ssl).status_code in (200, 401) else False
 except Exception as e:
     logging.exception(e)
     JAMF_UP = False

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 # jamf2snipe - Inventory Import
 #
 # ABOUT:
@@ -413,7 +413,7 @@ def get_snipe_users(previous=[]):
         'offset': len(previous)
     }
     logging.debug('The payload for the snipe users GET is {}'.format(payload))
-    response = requests.get(user_id_url, headers=snipeheaders, json=payload, hooks={'response': request_handler})
+    response = requests.get(user_id_url, headers=snipeheaders, params=payload, hooks={'response': request_handler})
     response_json = response.json()
     current = response_json['rows']
     if len(previous) != 0:
@@ -446,7 +446,7 @@ def get_snipe_user_id(username):
         'order':'asc'
     }
     logging.debug('The payload for the snipe user search is: {}'.format(payload))
-    response = requests.get(user_id_url, headers=snipeheaders, json=payload, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.get(user_id_url, headers=snipeheaders, params=payload, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     try:
         return response.json()['rows'][0]['id']
     except:
@@ -492,6 +492,7 @@ def update_snipe_asset(snipe_id, payload):
     if response.status_code == 200:
         logging.debug("Got back status code: 200 - Checking the payload updated properly: If you error here it's because you configure the API mapping right.")
         jsonresponse = response.json()
+       
         if jsonresponse['status'] == "error":
             logging.error('Unable to update ID: {}. Error "{}"'.format(snipe_id, jsonresponse['messages']))
             goodupdate = False

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -109,7 +109,7 @@ if 'snipe-it' not in set(config):
     logging.error("No valid settings.conf was found. We'll need to quit while you figure out where the settings are at. You can check the README for valid locations.")
     raise SystemExit("Error: No valid settings.conf - Exiting.")
 
-logging.info("Great, we found a settings file. Let's get started by parsing all fo the settings.")
+logging.info("Great, we found a settings file. Let's get started by parsing all of the settings.")
 
 # While setting the variables, use a try loop so we can raise a error if something goes wrong. 
 try:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -935,4 +935,4 @@ for jamf_type in jamf_types:
                       update_jamf_mobiledevice_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
                       logging.info("Device is a mobile device, updating the mobile device record")
 
-logging.debug('Total amount of API calls made: {}'.format(snipe_api_count))
+logging.debug('Total amount of API calls made: {}'.format(api_count))

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -67,7 +67,7 @@ user_opts = runtimeargs.add_mutually_exclusive_group()
 user_opts.add_argument("-u", "--users", help="Checks out the item to the current user in Jamf if it's not already deployed", action="store_true")
 user_opts.add_argument("-ui", "--users_inverse", help="Checks out the item to the current user in Jamf if it's already deployed", action="store_true")
 user_opts.add_argument("-uf", "--users_force", help="Checks out the item to the user specified in Jamf no matter what", action="store_true")
-user_opts.add_argument("-uns", "--users_no_search", help="Doesn't search for any users if the specified fields in Jamf and Snipe don't match. (case insensitive)", action="store_true")
+runtimeargs.add_argument("-uns", "--users_no_search", help="Doesn't search for any users if the specified fields in Jamf and Snipe don't match. (case insensitive)", action="store_true")
 type_opts = runtimeargs.add_mutually_exclusive_group()
 type_opts.add_argument("-m", "--mobiles", help="Runs against the Jamf mobiles endpoint only.", action="store_true")
 type_opts.add_argument("-c", "--computers", help="Runs against the Jamf computers endpoint only.", action="store_true")
@@ -492,7 +492,7 @@ def update_snipe_asset(snipe_id, payload):
     if response.status_code == 200:
         logging.debug("Got back status code: 200 - Checking the payload updated properly: If you error here it's because you configure the API mapping right.")
         jsonresponse = response.json()
-       
+        # Check if there's an Error and Log it, or parse the payload. 
         if jsonresponse['status'] == "error":
             logging.error('Unable to update ID: {}. Error "{}"'.format(snipe_id, jsonresponse['messages']))
             goodupdate = False

--- a/settings.conf.example
+++ b/settings.conf.example
@@ -8,12 +8,12 @@ password = a-valid-password
 url = https://FQDN.your.snipe.instance.com
 apikey = YOUR-API-KEY-HERE
 manufacturer_id = 2
-defaultStatus = 2 
+defaultStatus = 2
 computer_model_category_id = 2
 mobile_model_category_id = 3
 #Not Required, uncomment to use
-#computer_custom_fieldset_id = 3 
-#mobile_custom_fieldset_id = 4 
+#computer_custom_fieldset_id = 3
+#mobile_custom_fieldset_id = 4
 #asset_tag = general serial_number # If not specified, defaults to jamf-{id} or jamf-m-{id}
 
 [computers-api-mapping]

--- a/settings.conf.example
+++ b/settings.conf.example
@@ -1,7 +1,7 @@
 [jamf]
 # This entire section is Required
 url = https://yourinstance.jamfcloud.com
-user = yourJamfUsername
+username = yourJamfUsername
 password = $ecretJ@mfPassw0rd
 
 [snipe-it]


### PR DESCRIPTION
Brief Changelog:
- `--version` flag to assist with end user support (we can make sure we're running the current version of jamf2snipe)
- Better logging when missing required settings from settings.conf
- Token Bearer Auth (#80)
- Gets a token against the Jamf API as part of the dryrun, which has the added bonus of being another test in use with `--dryrun`
- Bug fix where the script would stop if MDM didn't have a serial number in the jamf entry yet. 