### PR TITLE
Handle missing asset tags in JAMF

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -794,6 +794,11 @@ for jamf_type in jamf_types:
                             jamf_asset_tag = 'jamfid-m-{}'.format(jamf['general']['id'])
                         elif jamf_type == 'computers':
                             jamf_asset_tag = 'jamfid-{}'.format(jamf['general']['id'])
+                        else:
+                            logging.error("Could not generate an asset tag for this device. Skipping")
+                            # Dump the object for debugging. 
+                            logging.verbose(jamf)
+                            continue
                         #raise SystemError('No such attribute {} in the jamf payload. Please check your settings.conf file'.format(tag_split))
                 if jamf_asset_tag == None or jamf_asset_tag == '':
                     logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -790,7 +790,11 @@ for jamf_type in jamf_types:
                     try:
                         jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
                     except:
-                        raise SystemError('No such attribute {} in the jamf payload. Please check your settings.conf file'.format(tag_split))
+                        if jamf_type == 'mobile_devices':
+                            jamf_asset_tag = 'jamfid-m-{}'.format(jamf['general']['id'])
+                        elif jamf_type == 'computers':
+                            jamf_asset_tag = 'jamfid-{}'.format(jamf['general']['id'])
+                        #raise SystemError('No such attribute {} in the jamf payload. Please check your settings.conf file'.format(tag_split))
                 if jamf_asset_tag == None or jamf_asset_tag == '':
                     logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')
                     if jamf_type == 'mobile_devices':


### PR DESCRIPTION
Change the try/except from a raise to an if that uses the code block to extract serial number when JAMF's asset tag is missing. There is probably a better way, but this resolves the error I had on issue: #91 