### PR TITLE
Fix XML headers for when updating JAMF's asset tags to match Snipe-IT's

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -30,7 +30,7 @@
 #       _snipeit_custom_name_1234567890 = subset jamf_key
 #
 #   A list of valid subsets are:
-version = "1.0.4"
+version = "1.0.5"
 
 validsubset = [
         "general",

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -197,6 +197,7 @@ def request_jamf_token():
     global token_request_time
     global jamf_apiKey
     global jamfheaders
+    global jamfxmlheaders
     global expires_time
     token_request_time = time.time()
     logging.info("Requesting a new token at {}.".format(token_request_time))
@@ -223,6 +224,7 @@ def request_jamf_token():
         # The headers are also global, because they get used elsewhere. 
         logging.info("Setting new jamf headers with bearer token") 
         jamfheaders = {'Authorization': 'Bearer {}'.format(jsonresponse['token']),'Accept': 'application/json','Content-Type':'application/json'}
+        jamfxmlheaders = {'Authorization': 'Bearer {}'.format(jsonresponse['token']),'Accept': 'application/xml','Content-Type':'application/xml'}
         logging.debug('Request headers for JamfPro will be: {}\nRequest headers for Snipe will be: {}'.format(jamfheaders, snipeheaders))
     else:
         logging.error("Could not obtain a token for use with Jamf's classic API. Please check your username and password.")
@@ -396,7 +398,7 @@ def update_jamf_asset_tag(jamf_id, asset_tag):
     api_url = "{}/JSSResource/computers/id/{}".format(jamfpro_base, jamf_id)
     payload = """<?xml version="1.0" encoding="UTF-8"?><computer><general><id>{}</id><asset_tag>{}</asset_tag></general></computer>""".format(jamf_id, asset_tag)
     logging.debug('Making Get request against: {}\nPayload for the PUT request is: {}\nThe username, password, and headers can be found near the beginning of the output.'.format(api_url, payload))
-    response = requests.put(api_url, data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.put(api_url, data=payload, headers=jamfxmlheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 201:
         logging.debug("Got a 201 response. Returning: True")
         return True
@@ -419,7 +421,7 @@ def update_jamf_mobiledevice_asset_tag(jamf_id, asset_tag):
     api_url = "{}/JSSResource/mobiledevices/id/{}".format(jamfpro_base, jamf_id)
     payload = """<?xml version="1.0" encoding="UTF-8"?><mobile_device><general><id>{}</id><asset_tag>{}</asset_tag></general></mobile_device>""".format(jamf_id, asset_tag)
     logging.debug('Making Get request against: {}\nPayload for the PUT request is: {}\nThe username, password, and headers can be found near the beginning of the output.'.format(api_url, payload))
-    response = requests.put(api_url, data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.put(api_url, data=payload, headers=jamfxmlheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 201:
         logging.debug("Got a 201 response. Returning: True")
         return True


### PR DESCRIPTION
Possible fix for #99 

[The proposed fix](https://github.com/grokability/jamf2snipe/issues/99#issuecomment-1442598552) by @hofftaylor looks like it *should* do the trick, so I just translated that into a PR.

When we send requests back to the JAMF server in order to update the asset tags for a computer or mobile asset, we need to set the appropriate XML headers - stating that we are sending XML, and we expect to receive XML in return. We were still sending JSON headers.

While the original authors of the fix were concerned that there might be a nicer way to do it, I don't see what that would be, other than abstracting things out too far and making everything harder to read. This is a simple fix that just adds two lines, and makes small changes to two lines. I don't think there's any point in over-optimizing such a change.

If anyone can test this - especially those who have been having the problem in #99 - I would love that. I'm working on getting a JAMF setup of my own working (and have had some who have offered), so I'd like to do some testing of my own, too. But I'd feel much better if other folks could try to check out this branch and see if it works any better for them.