### PR TITLE
added TypeError in catch exception

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -903,7 +903,7 @@ for jamf_type in jamf_types:
                                     jamf_value = jamf_value[item]
                         payload = {snipekey: jamf_value}
                         latestvalue = jamf_value
-                    except KeyError:
+                    except (KeyError, TypeError):
                         logging.debug("Skipping the payload, because the JAMF key we're mapping to doesn't exist")
                         continue
 


### PR DESCRIPTION
At line 903, TypeError is not handled in the the exception clause. This occurs when the array index is expecting integer but gets a str instead. 

```
Traceback (most recent call last):
  File "/Users/user/jamf2snipe/./jamf2snipe", line 903, in <module>
    jamf_value = jamf_value[item]
                 ~~~~~~~~~~^^^^^^
TypeError: list indices must be integers or slices, not str
```