### PR TITLE
Don't create blank modelnumbers

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -772,7 +772,7 @@ for jamf_type in jamf_types:
 
         # Check that the model number exists in snipe, if not create it.
         if jamf_type == 'computers':
-            if jamf['hardware']['model_identifier'] not in modelnumbers:
+            if jamf['hardware']['model_identifier'] not in modelnumbers and jamf['hardware']['model_identifier']:
                 logging.info("Could not find a model ID in snipe for: {}".format(jamf['hardware']['model_identifier']))
                 newmodel = {"category_id":config['snipe-it']['computer_model_category_id'],"manufacturer_id":apple_manufacturer_id,"name": jamf['hardware']['model'],"model_number":jamf['hardware']['model_identifier']}
                 if 'computer_custom_fieldset_id' in config['snipe-it']:
@@ -780,7 +780,7 @@ for jamf_type in jamf_types:
                     newmodel['fieldset_id'] = fieldset_split
                 create_snipe_model(newmodel)
         elif jamf_type == 'mobile_devices':
-            if jamf['general']['model_identifier'] not in modelnumbers:
+            if jamf['general']['model_identifier'] not in modelnumbers and jamf['general']['model_identifier']:
                 logging.info("Could not find a model ID in snipe for: {}".format(jamf['general']['model_identifier']))
                 newmodel = {"category_id":config['snipe-it']['mobile_model_category_id'],"manufacturer_id":apple_manufacturer_id,"name": jamf['general']['model'],"model_number":jamf['general']['model_identifier']}
                 if 'mobile_custom_fieldset_id' in config['snipe-it']:


### PR DESCRIPTION
We had a user report that they had a machine with bad data in Jamf --
missing fields like model, model identifier, etc...

`jamf['hardware']['model_identifier']` ended up being blank as a result,
and as there's no _blank_ modelnumber, it would try to create one....
which caused the script to crash.

In this change we head off that issue by not only checking whether or not
`jamf['hardware']['model_identifier']` is in modelnumbers, but whether or not it's blank

We do the same for `jamf['general']['model_identifier']`