### PR TITLE
Adding required privileges for Jamf's API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Note: do not add `""` or `''` around any values.
 
 **[jamf]**
 
+The minimum required privliages for Jamf's API key is Read Mobile Devices, Read Computers
+
 - `url`: https://*your_jamf_instance*.com:*port*
 - `client_id`: Jamf API client ID
 - `client_secret`: Jamf API client secret

--- a/settings.conf.example
+++ b/settings.conf.example
@@ -7,6 +7,7 @@ client_secret = yourClientSecret
 [snipe-it]
 #Required
 url = https://FQDN.your.snipe.instance.com
+#Minimum API required Privileges: Read Mobile Devices, Read Computers
 apikey = YOUR-API-KEY-HERE
 manufacturer_id = 2
 defaultStatus = 2


### PR DESCRIPTION
Jamf required API keys to have privileges, and only Read Mobile Devices, Read Computers are used as far as I can tell. 