### PR TITLE
Bump Script Version

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -30,7 +30,7 @@
 #       _snipeit_custom_name_1234567890 = subset jamf_key
 #
 #   A list of valid subsets are:
-version = "1.0.7"
+version = "1.0.8"
 
 validsubset = [
         "general",


### PR DESCRIPTION
There were a few fixes for issues including a mobile objects recursion bug and headers for the Jamf api calls. 